### PR TITLE
Bug fix for Kubernetes ≥1.33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ terraform.rc
 secrets/
 .kubeconfig
 dot-*
+.env*

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "vpc_database_subnet_cidr_b" {
 
 variable "eks_ami_type" {
   description = "AMI type for AWS EKS node group instances"
-  default     = "AL2_x86_64"
+  default     = "BOTTLEROCKET_x86_64"
 }
 
 variable "node_group_instance_type" {


### PR DESCRIPTION
Amazon Linux 2 (AL2) deprecated, not accepted in newer versions than Kubernetes 1.32. Now replaced by Bottlerocket OS. Resolves #1!